### PR TITLE
Continue block sequencing even if the integrity check raises exceptions

### DIFF
--- a/app/processors/converters.py
+++ b/app/processors/converters.py
@@ -760,8 +760,12 @@ class PolkascanHarvesterService(BaseService):
         return {'integrity_head': integrity_head.value}
 
     def start_sequencer(self):
-        integrity_status = self.integrity_checks()
-        self.db_session.commit()
+        # Continue even if the integrity check raises exceptions
+        try:
+            integrity_status = self.integrity_checks()
+            self.db_session.commit()
+        except BlockIntegrityError as e:
+            print(e)
 
         block_nr = None
 


### PR DESCRIPTION
I started the harvester from scratch and I found that block sequencing always stops at integrity check.
It doesn't make sense that we should wait for the integrity check.
The number of finalized blocks is increasing and `integrity_checks` always raises exceptions.