### PR TITLE
Fixed module_id string value of CodeStored event

### DIFF
--- a/app/processors/event.py
+++ b/app/processors/event.py
@@ -896,7 +896,7 @@ class TreasuryAwardedEventProcessor(EventProcessor):
 
 class CodeStoredEventProcessor(EventProcessor):
 
-    module_id = 'contract'
+    module_id = 'contracts'
     event_id = 'CodeStored'
 
     def accumulation_hook(self, db_session):


### PR DESCRIPTION
I cloned and deployed polkascan-os locally to harvest blocks from a substrate-based blockchain network with pallet-contracts enabled. It turns out that deployed contracts are not harvested into polkascan.data_contract table. 

I traced the issue, and found out that the module id of CodeStoredEventProcessor is misspelled. Thus, CodeStoredEventProcessor is not retrieved from ProcessorRegistry and invoked within PolkascanHarvesterService.add_block method.

This pull request corrects the module_id string value of contract CodeStored event.