### PR TITLE
Remove mysql-connector in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ Mako~=1.0.8
 MarkupSafe~=1.1.1
 meinheld~=1.0.2
 more-itertools~=6.0.0
-mysql-connector~=2.1.7
 mysql-connector-python~=8.0.15
 packaging~=19.1
 pluggy~=0.9.0


### PR DESCRIPTION
I use master branch to launch and received the error.

harvester-worker_1   | sqlalchemy.exc.NotSupportedError: (mysql.connector.errors.NotSupportedError) Authentication plugin 'caching_sha2_password' is not supported

Solution:
https://stackoverflow.com/questions/50557234/authentication-plugin-caching-sha2-password-is-not-supported

![image](https://user-images.githubusercontent.com/16951509/126951822-9d305d0e-30f8-4125-995e-19710ff6ab84.png)


